### PR TITLE
Index path fix

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -153,6 +153,7 @@ workflows:
     - path::./:
         title: Test one test result
         run_if: true
+        is_skippable: false
         inputs:
         - test_result_path: $TEST_RESULT_PATH
         - generate_junit: $GENERATE_JUNIT

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -13,6 +13,22 @@ app:
   - MULTIPLE_TEST_RESULT: "false"
 
 workflows:
+  ci_xcode_10:
+    description:
+      "Changing the install branch to master"
+    envs:
+    - INSTALL_BRANCH: "master"
+    after_run:
+    - ci
+
+  ci_xcode_11:
+    description:
+      "Changing the install branch to develop"
+    envs:
+    - INSTALL_BRANCH: "develop"
+    after_run:
+    - ci
+
   ci:
     before_run:
     - audit-this-step
@@ -51,8 +67,8 @@ workflows:
     envs:
     - MULTIPLE_TEST_RESULT: "false"
     - TEST_RESULT_PATH: ./Test.xcresult
-    - GENERATE_JUNIT: true
-    - VERBOSE: false
+    - GENERATE_JUNIT: "yes"
+    - VERBOSE: "yes"
     after_run:
     - common
     - run_test
@@ -61,8 +77,8 @@ workflows:
     envs:
     - MULTIPLE_TEST_RESULT: "false"
     - TEST_RESULT_PATH: ./Test.xcresult
-    - GENERATE_JUNIT: false
-    - VERBOSE: false
+    - GENERATE_JUNIT: "no"
+    - VERBOSE: "no"
     after_run:
     - common
     - run_test
@@ -74,8 +90,8 @@ workflows:
     envs:
     - MULTIPLE_TEST_RESULT: "false"
     - TEST_RESULT_PATH: ./Test.xcresult
-    - GENERATE_JUNIT: true
-    - VERBOSE: true
+    - GENERATE_JUNIT: "yes"
+    - VERBOSE: "yes"
     after_run:
     - common
     - run_test
@@ -84,8 +100,8 @@ workflows:
     envs:
     - MULTIPLE_TEST_RESULT: "false"
     - TEST_RESULT_PATH: ./Test.xcresult
-    - GENERATE_JUNIT: false
-    - VERBOSE: true
+    - GENERATE_JUNIT: "no"
+    - VERBOSE: "yes"
     after_run:
     - common
     - run_test
@@ -100,8 +116,8 @@ workflows:
         ./Test.xcresult
         ./Test_2.xcresult
         ./Test_3.xcresult
-    - GENERATE_JUNIT: true
-    - VERBOSE: false
+    - GENERATE_JUNIT: "yes"
+    - VERBOSE: "no"
     after_run:
     - common
     - run_test
@@ -113,8 +129,8 @@ workflows:
         ./Test.xcresult
         ./Test_2.xcresult
         ./Test_3.xcresult
-    - GENERATE_JUNIT: false
-    - VERBOSE: false
+    - GENERATE_JUNIT: "no"
+    - VERBOSE: "no"
     after_run:
     - common
     - run_test
@@ -129,8 +145,8 @@ workflows:
         ./Test.xcresult
         ./Test_2.xcresult
         ./Test_3.xcresult
-    - GENERATE_JUNIT: true
-    - VERBOSE: true
+    - GENERATE_JUNIT: "yes"
+    - VERBOSE: "yes"
     after_run:
     - common
     - run_test
@@ -142,8 +158,8 @@ workflows:
         ./Test.xcresult
         ./Test_2.xcresult
         ./Test_3.xcresult
-    - GENERATE_JUNIT: false
-    - VERBOSE: true
+    - GENERATE_JUNIT: "no"
+    - VERBOSE: "yes"
     after_run:
     - common
     - run_test
@@ -158,6 +174,7 @@ workflows:
         - test_result_path: $TEST_RESULT_PATH
         - generate_junit: $GENERATE_JUNIT
         - verbose: $VERBOSE
+        - install_branch: $INSTALL_BRANCH
 
   generate_test:
     envs:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "main.go"

--- a/main.go
+++ b/main.go
@@ -32,34 +32,42 @@ type Config struct {
 func exportReports(pth, outputDir string, generateJUnit bool, errors *[]error) (string, string, error) {
 
 	// Find the generated reports
-	// htmlReportPth := path.Join(pth, "index.html")
-	htmlReportPth := "index.html"
+	htmlReportPths := []string{"index.html", path.Join(pth, "index.html")}
 	junitPth := path.Join(pth, "report.junit")
 
 	//
 	// Check the report files
+	var exportedHTMLReportPth string
+	var exportedJUnitReportPth string
 	{
-		if exists, err := pathutil.IsPathExists(htmlReportPth); err != nil {
-			return "", "", fmt.Errorf("Failed to check if path exists, error: %s", err)
-		} else if !exists {
-			*errors = append(*errors, fmt.Errorf("HTML report does not exists in: %s", htmlReportPth))
+		// HTML report
+		for _, htmlReportPth := range htmlReportPths {
+			if exists, err := pathutil.IsPathExists(htmlReportPth); err != nil {
+				return "", "", fmt.Errorf("Failed to check if path exists, error: %s", err)
+			} else if !exists {
+				log.Debugf("HTML report does not exists in path: %s", htmlReportPth)
+			} else {
+				log.Debugf("Found HTML report in path: %s", htmlReportPth)
+				exportedHTMLReportPth = copy(htmlReportPth, outputDir, errors)
+				break
+			}
+		}
+		if exportedHTMLReportPth == "" {
+			*errors = append(*errors, fmt.Errorf("HTML report does not exists in paths: %s", strings.Join(htmlReportPths, ", ")))
 		}
 
+		// JUNIT
 		if generateJUnit {
 			if exists, err := pathutil.IsPathExists(junitPth); err != nil {
 				return "", "", fmt.Errorf("Failed to check if path exists, error: %s", err)
 			} else if !exists {
+				log.Debugf("JUnit report does not exists in: %s", junitPth)
 				*errors = append(*errors, fmt.Errorf("JUnit report does not exists in: %s", junitPth))
+			} else {
+				log.Debugf("Found JUNIT in path: %s", junitPth)
+				exportedJUnitReportPth = copy(junitPth, outputDir, errors)
 			}
 		}
-	}
-
-	//
-	// Copy reports
-	var exportedJUnitReportPth string
-	exportedHTMLReportPth := copy(htmlReportPth, outputDir, errors)
-	if generateJUnit {
-		exportedJUnitReportPth = copy(junitPth, outputDir, errors)
 	}
 
 	//

--- a/main.go
+++ b/main.go
@@ -31,7 +31,8 @@ type Config struct {
 func exportReports(pth, outputDir string, generateJUnit bool, errors *[]error) (string, string, error) {
 
 	// Find the generated reports
-	htmlReportPth := path.Join(pth, "index.html")
+	// htmlReportPth := path.Join(pth, "index.html")
+	htmlReportPth := "index.html"
 	junitPth := path.Join(pth, "report.junit")
 
 	//

--- a/main.go
+++ b/main.go
@@ -15,14 +15,15 @@ import (
 // Config ...
 type Config struct {
 	// XCHTMLReport
-	TestResults   string `env:"test_result_path,required"`
-	GenerateJUnit bool   `env:"generate_junit,required"`
+	TestResults   string        `env:"test_result_path,required"`
+	GenerateJUnit bool          `env:"generate_junit,opt[yes,no]"`
+	Branch        InstallBranch `env:"install_branch,opt[master,develop]"`
 
 	// Common
 	OutputDir string `env:"output_dir,dir"`
 
 	// Log
-	Verbose bool `env:"verbose,required"`
+	Verbose bool `env:"verbose,opt[yes,no]"`
 }
 
 // exportReports will search for the generated html and junit report
@@ -105,7 +106,7 @@ func main() {
 	{
 		log.Infof("Install XCTestHTMLReport via brew")
 
-		cmd := x.installCmd()
+		cmd := x.installCmd(cfg.Branch)
 		cmd.SetDir(dir).
 			SetStdout(os.Stdout).
 			SetStderr(os.Stderr)
@@ -113,6 +114,7 @@ func main() {
 		log.Printf("$ %s", cmd.PrintableCommandArgs())
 
 		if err := cmd.Run(); err != nil {
+			log.Warnf("Try to change the install branch of the XCTestHTMLReport")
 			failf("Failed to install XCTestHTMLReport, error: %s", err)
 		}
 

--- a/main.go
+++ b/main.go
@@ -170,5 +170,6 @@ func main() {
 		for _, err := range errors {
 			log.Errorf(err.Error())
 		}
+		os.Exit(1)
 	}
 }

--- a/step.yml
+++ b/step.yml
@@ -36,7 +36,7 @@ inputs:
         * ./test\_3.xctestresult
       is_required: true
 
-  - generate_junit: "true"
+  - generate_junit: "yes"
     opts:
       title: Generate JUnit report?
       summary: Generate JUnit report?
@@ -44,8 +44,8 @@ inputs:
         Provide JUnit XML output if enabled.
       is_required: true
       value_options:
-        - "true"
-        - "false"
+        - "yes"
+        - "no"
 
   - output_dir: $BITRISE_DEPLOY_DIR
     opts:
@@ -56,8 +56,22 @@ inputs:
 
         By default it's the `$BITRISE\_DEPLOY_DIR`
       is_required: "true"
+    
+  - install_branch: "develop"
+    opts:
+      title: Install branch of XCTestHTMLReport
+      summary: Select from which branch should the step install the tool
+      description: |
+        You can select from which branch do you want to install the XCTestHTMLReport.
+
+        **Master** for the stable version
+        **Develop** for the newest version
+      is_required: true
+      value_options:
+        - "develop"
+        - "master"
       
-  - verbose: "false"
+  - verbose: "no"
     opts:
       title: Enable verbose log?
       summary: Enable verbose log?
@@ -65,8 +79,8 @@ inputs:
         You can enable the verbose logging for troubleshooting purposes.
       is_required: true
       value_options:
-        - "true"
-        - "false"
+        - "yes"
+        - "no"
 
 outputs:
   - XC_HTML_REPORT:

--- a/xctesthtmlreport.go
+++ b/xctesthtmlreport.go
@@ -1,8 +1,21 @@
 package main
 
-import "github.com/bitrise-io/go-utils/command"
+import (
+	"fmt"
 
-const xcHTMLReportRepository string = "https://raw.githubusercontent.com/TitouanVanBelle/XCTestHTMLReport/develop/xchtmlreport.rb"
+	"github.com/bitrise-io/go-utils/command"
+)
+
+// InstallBranch is the selected source branch of the XCHTMLReport repository
+type InstallBranch string
+
+// enum SourceBranch
+const (
+	Develop InstallBranch = "develop"
+	Master  InstallBranch = "master"
+)
+
+const xcHTMLReportRepository string = "https://raw.githubusercontent.com/TitouanVanBelle/XCTestHTMLReport/%s/xchtmlreport.rb"
 
 type xcTestHTMLReport struct {
 	verbose           bool
@@ -13,8 +26,8 @@ type xcTestHTMLReport struct {
 //
 // Reciever methods
 
-func (xcTestHTMLReport) installCmd() *command.Model {
-	return command.New("brew", "install", xcHTMLReportRepository)
+func (xcTestHTMLReport) installCmd(branch InstallBranch) *command.Model {
+	return command.New("brew", "install", fmt.Sprintf(xcHTMLReportRepository, branch))
 }
 
 func (x xcTestHTMLReport) convertToHTMReportCmd() *command.Model {


### PR DESCRIPTION
**Description**
XCTestHTMLReport changed the path of the generated index.html.

**Changes**
- The step will fail if there were an error while exporting the reports.
- Disable `is_skippable` for test runs. The step still stays `is_skippable` enabled by default.
- Update the expected path of the generated index.html
- Add `install_branch` input
You can select from which branch do you want to install the XCTestHTMLReport.
**Master** for the stable version
**Develop** for the newest version

**Fixes**
https://github.com/BirmacherAkos/bitrise-step-xctest-html-report/issues/11