### PR TITLE
Fix: Brew fails to install the step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .bitrise*
 _tmp
+install.sh
+__MACOSX/._xchtmlreport

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -15,17 +15,25 @@ app:
 workflows:
   ci_xcode_10:
     description:
-      "Changing the install branch to master"
+      "Using 1.7.0 version"
     envs:
-    - INSTALL_BRANCH: "master"
+    - VERSION: "1.7.0"
     after_run:
     - ci
 
   ci_xcode_11:
     description:
-      "Changing the install branch to develop"
+      "Using 2.0.0 version"
     envs:
-    - INSTALL_BRANCH: "develop"
+    - VERSION: "2.0.0"
+    after_run:
+    - ci
+
+  ci_xcode_12:
+    description:
+      "Using latest version"
+    envs:
+    - VERSION: "latest"
     after_run:
     - ci
 
@@ -174,7 +182,7 @@ workflows:
         - test_result_path: $TEST_RESULT_PATH
         - generate_junit: $GENERATE_JUNIT
         - verbose: $VERBOSE
-        - install_branch: $INSTALL_BRANCH
+        - version: $VERSION
 
   generate_test:
     envs:

--- a/githubrelease.go
+++ b/githubrelease.go
@@ -25,7 +25,10 @@ func latestGithubRelease(githubOrg, githubRepository string, accessToken stepcon
 	if err != nil {
 		return GithubRelease{}, fmt.Errorf("failed to create new request for %s, error: %v", url, err)
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("token %s", string(accessToken)))
+
+	if string(accessToken) != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("token %s", string(accessToken)))
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/githubrelease.go
+++ b/githubrelease.go
@@ -37,7 +37,9 @@ func latestGithubRelease(githubOrg, githubRepository string) (GithubRelease, err
 		return GithubRelease{}, fmt.Errorf("failed to read response body from the %s, error: %v", url, err)
 	}
 	var githubRelease GithubRelease
-	json.Unmarshal([]byte(body), &githubRelease)
+	if err := json.Unmarshal([]byte(body), &githubRelease); err != nil {
+		return githubRelease, fmt.Errorf("failed to parse latest Github Release JSON, ewrror: %v", err)
+	}
 
 	return githubRelease, nil
 }

--- a/githubrelease.go
+++ b/githubrelease.go
@@ -31,7 +31,7 @@ func latestGithubRelease(githubOrg, githubRepository string, accessToken stepcon
 	if err != nil {
 		return GithubRelease{}, fmt.Errorf("failed to call the %s, error: %v", url, err)
 	} else if resp.StatusCode != http.StatusOK {
-		return GithubRelease{}, fmt.Errorf("response status %s")
+		return GithubRelease{}, fmt.Errorf("response status %v", resp.StatusCode)
 	}
 
 	log.Debugf("Response status: %s", resp.Status)

--- a/githubrelease.go
+++ b/githubrelease.go
@@ -30,11 +30,8 @@ func latestGithubRelease(githubOrg, githubRepository string, accessToken stepcon
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return GithubRelease{}, fmt.Errorf("failed to call the %s, error: %v", url, err)
-	} else if resp.StatusCode != http.StatusOK {
-		return GithubRelease{}, fmt.Errorf("response status %v", resp.StatusCode)
 	}
 
-	log.Debugf("Response status: %s", resp.Status)
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
 			log.Warnf("Failed to close response body, error: %v", cerr)
@@ -45,6 +42,12 @@ func latestGithubRelease(githubOrg, githubRepository string, accessToken stepcon
 	if err != nil {
 		return GithubRelease{}, fmt.Errorf("failed to read response body from the %s, error: %v", url, err)
 	}
+
+	if resp.StatusCode != http.StatusOK {
+		return GithubRelease{}, fmt.Errorf("response status %v, body: %s", resp.StatusCode, string(body))
+	}
+	log.Debugf("Response status: %s", resp.Status)
+
 	var githubRelease GithubRelease
 	if err := json.Unmarshal([]byte(body), &githubRelease); err != nil {
 		return githubRelease, fmt.Errorf("failed to parse latest Github Release JSON, ewrror: %v", err)

--- a/githubrelease.go
+++ b/githubrelease.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/bitrise-io/go-utils/log"
+)
+
+// GithubRelease returned from the Github API
+type GithubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+// https://api.github.com/repos/TitouanVanBelle/XCTestHTMLReport/releases/latest
+
+// Returns the information of the latest release from the Github API for the provided repository
+// More: https://docs.github.com/en/rest/reference/repos#releases
+func latestGithubRelease(githubOrg, githubRepository string) (GithubRelease, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", githubOrg, githubRepository)
+	resp, err := http.Get(url)
+	if err != nil {
+		return GithubRelease{}, fmt.Errorf("failed to call the %s, error: %v", url, err)
+	}
+
+	log.Debugf("Response status: %s", resp.Status)
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			log.Warnf("Failed to close response body, error: %v", cerr)
+		}
+	}()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return GithubRelease{}, fmt.Errorf("failed to read response body from the %s, error: %v", url, err)
+	}
+	var githubRelease GithubRelease
+	json.Unmarshal([]byte(body), &githubRelease)
+
+	return githubRelease, nil
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/bitrise-io/go-utils/pathutil"
 )
 
+const fallbackVersion = "2.0.0"
+
 // Config ...
 type Config struct {
 	// Authentication
@@ -112,10 +114,12 @@ func main() {
 		log.Printf("Latest version selected, identify the latest version on Github")
 		release, err := latestGithubRelease(xcHTMLReportGithubOrg, xcHTMLReportGithubRepo, cfg.GithubAccessToken)
 		if err != nil {
-			failf("Failed to identify the latest Github release of the XCTestHTMLReport, error: %s\nTry to add Github Access Token to the step to avoid API rate limit.", err)
+			log.Warnf("Failed to identify the latest Github release of the XCTestHTMLReport, error: %s\nTry to add Github Access Token to the step to avoid API rate limit.\nUsing the known latest version: %s", err, fallbackVersion)
+			version = fallbackVersion
+		} else {
+			version = release.TagName
+			fmt.Printf("Latest version: %s\n", version)
 		}
-		version = release.TagName
-		fmt.Printf("Latest version: %s\n", version)
 	}
 
 	x := xcTestHTMLReport{

--- a/main.go
+++ b/main.go
@@ -107,8 +107,8 @@ func main() {
 		failf("Failed to get current directory, error: %s", err)
 	}
 
-	version := "latest"
-	if version == "latest" {
+	var version string
+	if cfg.Version == "latest" {
 		log.Printf("Latest version selected, identify the latest version on Github")
 		release, err := latestGithubRelease(xcHTMLReportGithubOrg, xcHTMLReportGithubRepo, cfg.GithubAccessToken)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -19,9 +19,9 @@ type Config struct {
 	GithubAccessToken stepconf.Secret `env:"github_access_token"`
 
 	// XCHTMLReport
-	TestResults   string        `env:"test_result_path,required"`
-	GenerateJUnit bool          `env:"generate_junit,opt[yes,no]"`
-	Branch        InstallBranch `env:"install_branch,opt[master,develop]"`
+	TestResults   string `env:"test_result_path,required"`
+	GenerateJUnit bool   `env:"generate_junit,opt[yes,no]"`
+	Version       string `env:"version,required"`
 
 	// Common
 	OutputDir string `env:"output_dir,dir"`

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 	fmt.Println()
 
 	testResults := strings.Split(strings.TrimRight(cfg.TestResults, "\n"), "\n")
-	log.SetEnableDebugLog(true)
+	log.SetEnableDebugLog(cfg.Verbose)
 
 	dir, err := os.Getwd()
 	if err != nil {
@@ -115,7 +115,7 @@ func main() {
 			failf("Failed to identify the latest Github release of the XCTestHTMLReport")
 		}
 		version = release.TagName
-		fmt.Printf("Latest version: %s", version)
+		fmt.Printf("Latest version: %s\n", version)
 	}
 
 	x := xcTestHTMLReport{

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func main() {
 
 	version := "latest"
 	if version == "latest" {
-		release, err := latestGithubRelease(XcHTMLReportGithubOrg, XcHTMLReportGithubRepo)
+		release, err := latestGithubRelease(xcHTMLReportGithubOrg, xcHTMLReportGithubRepo)
 		if err != nil {
 			failf("Failed to identify the latest Github release of the XCTestHTMLReport")
 		}

--- a/main.go
+++ b/main.go
@@ -106,11 +106,13 @@ func main() {
 
 	version := "latest"
 	if version == "latest" {
+		log.Printf("Latest version selected, identify the latest version on Github")
 		release, err := latestGithubRelease(xcHTMLReportGithubOrg, xcHTMLReportGithubRepo)
 		if err != nil {
 			failf("Failed to identify the latest Github release of the XCTestHTMLReport")
 		}
 		version = release.TagName
+		fmt.Printf("Latest version: %s", version)
 	}
 
 	x := xcTestHTMLReport{

--- a/main.go
+++ b/main.go
@@ -110,24 +110,39 @@ func main() {
 	}
 
 	//
-	// Install
+	// Install via Brew
+	// Deprecated
+	// {
+	// 	log.Infof("Install XCTestHTMLReport via brew")
+
+	// 	cmd := x.installCmd(cfg.Branch)
+	// 	cmd.SetDir(dir).
+	// 		SetStdout(os.Stdout).
+	// 		SetStderr(os.Stderr)
+
+	// 	log.Printf("$ %s", cmd.PrintableCommandArgs())
+
+	// 	if err := cmd.Run(); err != nil {
+	// 		log.Warnf("Try to change the install branch of the XCTestHTMLReport")
+	// 		failf("Failed to install XCTestHTMLReport, error: %s", err)
+	// 	}
+
+	// 	log.Successf("XCTestHTMLReport successfully installed")
+	// 	fmt.Println()
+	// }
+
+	// Install via install script
 	{
-		log.Infof("Install XCTestHTMLReport via brew")
+		log.Infof("Install XCTestHTMLReport via install script")
+		log.Printf("Download install script")
+		if err := x.downloadInstallScript(); err != nil {
+			failf("Failed to download the install script of the XCTestHTMLReport")
+		}
 
 		cmd := x.installCmd(cfg.Branch)
 		cmd.SetDir(dir).
 			SetStdout(os.Stdout).
 			SetStderr(os.Stderr)
-
-		log.Printf("$ %s", cmd.PrintableCommandArgs())
-
-		if err := cmd.Run(); err != nil {
-			log.Warnf("Try to change the install branch of the XCTestHTMLReport")
-			failf("Failed to install XCTestHTMLReport, error: %s", err)
-		}
-
-		log.Successf("XCTestHTMLReport successfully installed")
-		fmt.Println()
 	}
 
 	//

--- a/main.go
+++ b/main.go
@@ -107,8 +107,8 @@ func main() {
 		failf("Failed to get current directory, error: %s", err)
 	}
 
-	var version string
-	if cfg.Version == "latest" {
+	version := cfg.Version
+	if version == "latest" {
 		log.Printf("Latest version selected, identify the latest version on Github")
 		release, err := latestGithubRelease(xcHTMLReportGithubOrg, xcHTMLReportGithubRepo, cfg.GithubAccessToken)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -161,14 +161,20 @@ func main() {
 			log.Debugf("Write the install script to the install.sh file")
 			outFile, err := os.Create("install.sh")
 			// handle err
-			defer outFile.Close()
+			defer func() {
+				if cerr := outFile.Close(); err != nil {
+					log.Warnf("Failed to close the output file (install.sh) after writing in it, error: %v", cerr)
+				}
+			}()
 			_, err = outFile.WriteString(script)
 			if err != nil {
 				fmt.Printf("failed to write the install script to the install.sh file, error:  %v", err)
 			}
 
 			log.Debugf("Make executable the install.sh file")
-			os.Chmod("install.sh", 0777)
+			if err := os.Chmod("install.sh", 0777); err != nil {
+				log.Errorf("failed to change access permission of the install.sh file, error: %v", err)
+			}
 
 			log.Printf("Running install.sh")
 			cmd := x.installViaScriptCmd(x.version)

--- a/main.go
+++ b/main.go
@@ -15,6 +15,9 @@ import (
 
 // Config ...
 type Config struct {
+	// Authentication
+	GithubAccessToken stepconf.Secret `env:"github_access_token"`
+
 	// XCHTMLReport
 	TestResults   string        `env:"test_result_path,required"`
 	GenerateJUnit bool          `env:"generate_junit,opt[yes,no]"`
@@ -107,7 +110,7 @@ func main() {
 	version := "latest"
 	if version == "latest" {
 		log.Printf("Latest version selected, identify the latest version on Github")
-		release, err := latestGithubRelease(xcHTMLReportGithubOrg, xcHTMLReportGithubRepo)
+		release, err := latestGithubRelease(xcHTMLReportGithubOrg, xcHTMLReportGithubRepo, cfg.GithubAccessToken)
 		if err != nil {
 			failf("Failed to identify the latest Github release of the XCTestHTMLReport")
 		}

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func main() {
 		log.Printf("Latest version selected, identify the latest version on Github")
 		release, err := latestGithubRelease(xcHTMLReportGithubOrg, xcHTMLReportGithubRepo, cfg.GithubAccessToken)
 		if err != nil {
-			failf("Failed to identify the latest Github release of the XCTestHTMLReport")
+			failf("Failed to identify the latest Github release of the XCTestHTMLReport, error: %s\nTry to add Github Access Token to the step to avoid API rate limit.", err)
 		}
 		version = release.TagName
 		fmt.Printf("Latest version: %s\n", version)

--- a/main.go
+++ b/main.go
@@ -197,6 +197,7 @@ func main() {
 	} else {
 		log.Successf("Already installed")
 	}
+	fmt.Println()
 
 	//
 	// Generate reports
@@ -205,6 +206,7 @@ func main() {
 		if cfg.GenerateJUnit {
 			info = "Generating html and JUnit report"
 		}
+
 		log.Infof(info)
 
 		cmd := x.convertToHTMReportCmd()

--- a/step.yml
+++ b/step.yml
@@ -22,6 +22,15 @@ toolkit:
     package_name: github.com/BirmacherAkos/bitrise-step-xctest-html-report
 
 inputs:
+  - github_access_token: $GITHUB_ACCESS_TOKEN
+    opts:
+      title: Github Personal Access Token
+      description: |-
+        Use this input to avoid Github rate limit issues.
+        See the github's guide: [Creating an access token for command-line use](https://help.github.com/articles/creating-an-access-token-for-command-line-use/),   
+        how to create Personal Access Token.
+        __UNCHECK EVERY SCOPE BOX__ when creating this token. There is no reason this token needs access to private information.
+      is_sensitive: true
   - test_result_path: $BITRISE_XCRESULT_PATH
     opts:
       title: Xcode test result (.xctesresult) paths

--- a/step.yml
+++ b/step.yml
@@ -25,6 +25,7 @@ inputs:
   - github_access_token: $GITHUB_ACCESS_TOKEN
     opts:
       title: Github Personal Access Token
+      summary: Use this input to avoid Github rate limit issues for the XCTestHTMLReport download
       description: |-
         Use this input to avoid Github rate limit issues.
         See the github's guide: [Creating an access token for command-line use](https://help.github.com/articles/creating-an-access-token-for-command-line-use/),   

--- a/step.yml
+++ b/step.yml
@@ -28,8 +28,7 @@ inputs:
       summary: Use this input to avoid Github rate limit issues for the XCTestHTMLReport download
       description: |-
         Use this input to avoid Github rate limit issues.
-        See the github's guide: [Creating an access token for command-line use](https://help.github.com/articles/creating-an-access-token-for-command-line-use/),   
-        how to create Personal Access Token.
+        See the github's guide: [Creating an access token for command-line use](https://help.github.com/articles/creating-an-access-token-for-command-line-use/).
         __UNCHECK EVERY SCOPE BOX__ when creating this token. There is no reason this token needs access to private information.
       is_sensitive: true
   - test_result_path: $BITRISE_XCRESULT_PATH
@@ -67,15 +66,13 @@ inputs:
         By default it's the `$BITRISE\_DEPLOY_DIR`
       is_required: "true"
     
-  - install_branch: "develop"
+  - version: "latest"
     opts:
-      title: Install branch of XCTestHTMLReport
-      summary: Select from which branch should the step install the tool
+      title: Version of the XCTestHTMLReport
+      summary: Select which version to install
       description: |
-        You can select from which branch do you want to install the XCTestHTMLReport.
-
-        **Master** for the stable version
-        **Develop** for the newest version
+        The version of XCTestHTMLReport you want to use from https://github.com/TitouanVanBelle/XCTestHTMLReport/releases.
+        If the value is set to `latest`, the step will download to the latest XCTestHTMLReport version.
       is_required: true
       value_options:
         - "develop"

--- a/step.yml
+++ b/step.yml
@@ -22,7 +22,7 @@ toolkit:
     package_name: github.com/BirmacherAkos/bitrise-step-xctest-html-report
 
 inputs:
-  - github_access_token: $GITHUB_ACCESS_TOKEN
+  - github_access_token:
     opts:
       title: Github Personal Access Token
       summary: Use this input to avoid Github rate limit issues for the XCTestHTMLReport download

--- a/utils.go
+++ b/utils.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path"
+	"strings"
 
 	"github.com/bitrise-io/go-utils/log"
 )
@@ -38,6 +40,12 @@ func copy(sourcePath, outputDir string, errors *[]error) string {
 	}
 
 	return destinationPath
+}
+
+func installedInPath(name string) bool {
+	cmd := exec.Command("which", name)
+	outBytes, err := cmd.Output()
+	return err == nil && strings.TrimSpace(string(outBytes)) != ""
 }
 
 func failf(format string, v ...interface{}) {

--- a/xctesthtmlreport.go
+++ b/xctesthtmlreport.go
@@ -61,7 +61,7 @@ func (x xcTestHTMLReport) installScript() (string, error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("response status %s")
+		return "", fmt.Errorf("response status %v", resp.StatusCode)
 	}
 
 	buf := new(bytes.Buffer)

--- a/xctesthtmlreport.go
+++ b/xctesthtmlreport.go
@@ -61,7 +61,9 @@ func (x xcTestHTMLReport) installScript() (string, error) {
 	}()
 
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(resp.Body)
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return "", fmt.Errorf("failed to copy the response body to a buffer, error: %v", err)
+	}
 	return buf.String(), nil
 }
 

--- a/xctesthtmlreport.go
+++ b/xctesthtmlreport.go
@@ -20,8 +20,8 @@ const (
 
 const xcHTMLReportRepository string = "https://raw.githubusercontent.com/TitouanVanBelle/XCTestHTMLReport/%s/xchtmlreport.rb"
 const xcHTMLReportInstallScriptURL string = "https://raw.githubusercontent.com/TitouanVanBelle/XCTestHTMLReport/master/install.sh"
-const XcHTMLReportGithubOrg string = "TitouanVanBelle"
-const XcHTMLReportGithubRepo string = "XCTestHTMLReport"
+const xcHTMLReportGithubOrg string = "TitouanVanBelle"
+const xcHTMLReportGithubRepo string = "XCTestHTMLReport"
 
 type xcTestHTMLReport struct {
 	verbose           bool

--- a/xctesthtmlreport.go
+++ b/xctesthtmlreport.go
@@ -20,11 +20,14 @@ const (
 
 const xcHTMLReportRepository string = "https://raw.githubusercontent.com/TitouanVanBelle/XCTestHTMLReport/%s/xchtmlreport.rb"
 const xcHTMLReportInstallScriptURL string = "https://raw.githubusercontent.com/TitouanVanBelle/XCTestHTMLReport/master/install.sh"
+const XcHTMLReportGithubOrg string = "TitouanVanBelle"
+const XcHTMLReportGithubRepo string = "XCTestHTMLReport"
 
 type xcTestHTMLReport struct {
 	verbose           bool
 	generateJUnit     bool
 	resultBundlePaths []string
+	version           string
 }
 
 //
@@ -32,6 +35,10 @@ type xcTestHTMLReport struct {
 // Deprecated:
 func (xcTestHTMLReport) installCmd(branch InstallBranch) *command.Model {
 	return command.New("brew", "install", fmt.Sprintf(xcHTMLReportRepository, branch))
+}
+
+func (xcTestHTMLReport) installViaScriptCmd(version string) *command.Model {
+	return command.New("/bin/sh", []string{"install.sh", version}...)
 }
 
 func (x xcTestHTMLReport) convertToHTMReportCmd() *command.Model {

--- a/xctesthtmlreport.go
+++ b/xctesthtmlreport.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/log"
 )
 
 // InstallBranch is the selected source branch of the XCHTMLReport repository
@@ -16,6 +18,7 @@ const (
 )
 
 const xcHTMLReportRepository string = "https://raw.githubusercontent.com/TitouanVanBelle/XCTestHTMLReport/%s/xchtmlreport.rb"
+const xcHTMLReportInstallScriptURL string = "https://raw.githubusercontent.com/TitouanVanBelle/XCTestHTMLReport/master/install.sh"
 
 type xcTestHTMLReport struct {
 	verbose           bool
@@ -32,6 +35,24 @@ func (xcTestHTMLReport) installCmd(branch InstallBranch) *command.Model {
 
 func (x xcTestHTMLReport) convertToHTMReportCmd() *command.Model {
 	return command.New("xchtmlreport", convertToHTMReportArgs(x)...)
+}
+
+// downloadInstallScript downloads the install script located on the master branch of the XCTestHTMLReport repository
+// https://raw.githubusercontent.com/TitouanVanBelle/XCTestHTMLReport/master/install.sh
+func (x xcTestHTMLReport) downloadInstallScript() error {
+	resp, err := http.Get(xcHTMLReportInstallScriptURL)
+	if err != nil {
+		return fmt.Errorf("failed to call the %s, error: %v", xcHTMLReportInstallScriptURL, err)
+	}
+	log.Debugf("Response status: %s", resp.Status)
+
+	defer func() {
+		if cerr := resp.Body.Close(); err != nil {
+			log.Warnf("Failed to close response body of %s, error: %v", xcHTMLReportInstallScriptURL, cerr)
+		}
+	}()
+
+	return nil
 }
 
 //

--- a/xctesthtmlreport.go
+++ b/xctesthtmlreport.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 
@@ -37,12 +38,12 @@ func (x xcTestHTMLReport) convertToHTMReportCmd() *command.Model {
 	return command.New("xchtmlreport", convertToHTMReportArgs(x)...)
 }
 
-// downloadInstallScript downloads the install script located on the master branch of the XCTestHTMLReport repository
+// installScript returns the install script located on the master branch of the XCTestHTMLReport repository
 // https://raw.githubusercontent.com/TitouanVanBelle/XCTestHTMLReport/master/install.sh
-func (x xcTestHTMLReport) downloadInstallScript() error {
+func (x xcTestHTMLReport) installScript() (string, error) {
 	resp, err := http.Get(xcHTMLReportInstallScriptURL)
 	if err != nil {
-		return fmt.Errorf("failed to call the %s, error: %v", xcHTMLReportInstallScriptURL, err)
+		return "", fmt.Errorf("failed to call the %s, error: %v", xcHTMLReportInstallScriptURL, err)
 	}
 	log.Debugf("Response status: %s", resp.Status)
 
@@ -52,7 +53,9 @@ func (x xcTestHTMLReport) downloadInstallScript() error {
 		}
 	}()
 
-	return nil
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	return buf.String(), nil
 }
 
 //

--- a/xctesthtmlreport.go
+++ b/xctesthtmlreport.go
@@ -60,6 +60,10 @@ func (x xcTestHTMLReport) installScript() (string, error) {
 		}
 	}()
 
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("response status %s")
+	}
+
 	buf := new(bytes.Buffer)
 	if _, err := buf.ReadFrom(resp.Body); err != nil {
 		return "", fmt.Errorf("failed to copy the response body to a buffer, error: %v", err)

--- a/xctesthtmlreport.go
+++ b/xctesthtmlreport.go
@@ -25,7 +25,7 @@ type xcTestHTMLReport struct {
 
 //
 // Reciever methods
-
+// Deprecated:
 func (xcTestHTMLReport) installCmd(branch InstallBranch) *command.Model {
 	return command.New("brew", "install", fmt.Sprintf(xcHTMLReportRepository, branch))
 }


### PR DESCRIPTION
Installing the XcTestHTMLReport tool via the install script located in the tool's repository.

**Changes**

1. The branch selector got removed
2. Version selector added instead
3. The tool will not be installed via Homebrew anymore
4. Optionaly you can provide a Github Access Token to avoid the API rate limit

**Fixes**
https://github.com/BirmacherAkos/bitrise-step-xctest-html-report/issues/17
